### PR TITLE
changed Defiant connection address to 'defiant-login.ccs.ornl.gov'.

### DIFF
--- a/ace_testbed/defiant_quick_start_guide.rst
+++ b/ace_testbed/defiant_quick_start_guide.rst
@@ -86,11 +86,11 @@ TB/s.
 Connecting
 ==========
 
-To connect to Defiant, ``ssh`` to ``defiant-login[1-2].olcf.ornl.gov``. For example:
+To connect to Defiant, ``ssh`` to ``defiant-login.ccs.ornl.gov``. For example:
 
 .. code-block:: bash
 
-    $ ssh username@defiant-login1.olcf.ornl.gov
+    $ ssh username@defiant-login.ccs.ornl.gov
 
 For more information on connecting to OLCF resources, see :ref:`connecting-to-olcf`.
 


### PR DESCRIPTION
Updating "Connecting to Defiant" to show the correct url.